### PR TITLE
アイコンを登録できるようにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'jbuilder', '~> 2.7'
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
+gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,6 +336,7 @@ DEPENDENCIES
   erb_lint
   faker
   i18n_generators
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   kaminari
   letter_opener_web

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    keys = %i[name postal_code address self_introduction]
+    keys = %i[name postal_code address self_introduction avatar]
     devise_parameter_sanitizer.permit(:sign_up, keys: keys)
     devise_parameter_sanitizer.permit(:account_update, keys: keys)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@
 
 class UsersController < ApplicationController
   def index
-    @users = User.order(:id).page(params[:page])
+    @users = User.with_attached_avatar.order(:id).page(params[:page])
   end
 
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_one_attached :avatar
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -33,6 +33,12 @@
     <%= f.password_field :current_password, autocomplete: "current-password" %>
   </div>
 
+  <div class="field">
+    <%= f.label :avatar %>
+    <%= f.file_field :avatar %>
+  </div>
+
+
   <div class="actions">
     <%= f.submit t('.update') %>
   </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -38,7 +38,6 @@
     <%= f.file_field :avatar %>
   </div>
 
-
   <div class="actions">
     <%= f.submit t('.update') %>
   </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -20,7 +20,8 @@
         <td><%= user.postal_code %></td>
         <td><%= user.address %></td>
         <% if user.avatar.attached? %>
-          <td><%= image_tag user.avatar %></td>
+          <td><%= image_tag user.avatar.variant(resize_to_limit: [50, 50], quality: 80) %>
+          </td>
         <% else %>
           <td></td>
         <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -7,6 +7,7 @@
       <th><%= User.human_attribute_name(:name) %></th>
       <th><%= User.human_attribute_name(:postal_code) %></th>
       <th><%= User.human_attribute_name(:address) %></th>
+      <th><%= User.human_attribute_name(:avatar) %></th>
       <th></th>
     </tr>
   </thead>
@@ -18,6 +19,11 @@
         <td><%= user.name %></td>
         <td><%= user.postal_code %></td>
         <td><%= user.address %></td>
+        <% if user.avatar.attached? %>
+          <td><%= image_tag user.avatar %></td>
+        <% else %>
+          <td></td>
+        <% end %>
         <td><%= link_to t('views.common.show'), user %></td>
       </tr>
     <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -20,7 +20,7 @@
         <td><%= user.postal_code %></td>
         <td><%= user.address %></td>
         <% if user.avatar.attached? %>
-          <td><%= image_tag user.avatar.variant(resize_to_limit: [50, 50], quality: 80) %>
+          <td><%= image_tag user.avatar.variant(resize_to_limit: [30, 30], quality: 80) %>
           </td>
         <% else %>
           <td></td>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -28,7 +28,7 @@
 <p>
   <strong><%= User.human_attribute_name(:avatar) %>:</strong>
   <% if @user.avatar.attached? %>
-    <%= image_tag user.avatar.variant(resize_to_limit: [100, 100], quality: 80) %>
+    <%= image_tag @user.avatar.variant(resize_to_limit: [50, 50], quality: 80) %>
 <% end %>
 </p>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -28,8 +28,8 @@
 <p>
   <strong><%= User.human_attribute_name(:avatar) %>:</strong>
   <% if @user.avatar.attached? %>
-    <%= image_tag @user.avatar %>
-  <% end %>
+    <%= image_tag user.avatar.variant(resize_to_limit: [100, 100], quality: 80) %>
+<% end %>
 </p>
 
 <% if current_user == @user %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -25,6 +25,13 @@
   <%= @user.self_introduction %>
 </p>
 
+<p>
+  <strong><%= User.human_attribute_name(:avatar) %>:</strong>
+  <% if @user.avatar.attached? %>
+    <%= image_tag @user.avatar %>
+  <% end %>
+</p>
+
 <% if current_user == @user %>
   <%= link_to t('views.common.edit'), edit_user_registration_path %> |
 <% end %>

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -15,3 +15,4 @@ ja:
         postal_code: 郵便番号
         address: 住所
         self_introduction: 自己紹介文
+        avatar: アイコン

--- a/db/migrate/20221230040623_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20221230040623_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,36 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_31_231050) do
+ActiveRecord::Schema.define(version: 2022_12_30_040623) do
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.integer "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "books", force: :cascade do |t|
     t.string "title"
@@ -37,4 +65,6 @@ ActiveRecord::Schema.define(version: 2021_05_31_231050) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
- [x] ユーザーが自分のアイコン画像をアップロードできるようにする
- [x] ユーザー一覧画面とユーザー詳細画面にアイコンを表示する（未アップロードなら何も表示しない）
- [x] 画像を表示する際、大きすぎる画像は適切なサイズにリサイズする（ファイルの容量を小さくしてネットワークの負荷を減らす）
- [x] ユーザー一覧画面とユーザー詳細画面のスクリーンショットを載せる
- [x] rubocopとerblintをパスさせる（要スクリーンショット）